### PR TITLE
this gets load working again

### DIFF
--- a/example/bin
+++ b/example/bin
@@ -22,8 +22,8 @@ var { close, remoteCall } = require('../wrapper')({
     })
   },
   callhost: (cb) => {
-    remoteCall('sync', 'getAddress', [], (err, addr) => {
-      console.log('got addr', err, addr)
+    remoteCall('sync', 'address', ['device'], (err, addr) => {
+      console.error('got addr', err, addr)
       cb(err, addr)
     })
   },

--- a/load.js
+++ b/load.js
@@ -1,14 +1,18 @@
+var path = require('path')
 module.exports = (location) => {
-  const {child, manifest} = require('./run')(location)
+  const manifest = require(path.join(location, 'manifest.json'))
   return {
-	// caller has to set name
-	version: 'alpha?',
-	manifest: manifest,
-	init: (server, conf) => {
-	  // TODO: how do I pass server to it without creating a loop?
-	  var api = require('muxrpc/api')(server, manifest, child)
-	  console.log('load returning',api)
-	  return api
-	}
+  // caller has to set name
+  version: 'alpha?',
+  manifest: manifest,
+  init: (server, conf) => {
+    const localCall = require('muxrpc/local-api')(server, server.getManifest())
+    //prefer not to start child process intil plugin is initialized
+    //otherwise this would fail when testing multiple sbot instances.
+    const {child} = require('./run')(location, localCall)
+    // TODO: how do I pass server to it without creating a loop?
+    return require('muxrpc/api')(server, manifest, child)
+  }
   }
 }
+

--- a/run.js
+++ b/run.js
@@ -11,6 +11,7 @@ function run(path, localCall) {
     require('packet-stream-codec'),
     function onClose() {
       // ??
+      proc.kill(9)
     }
   )
 
@@ -26,6 +27,7 @@ function run(path, localCall) {
   )
 
   return {
+    //sream... you mean stream?
     sream: stream.remoteCall,
     proc: proc,
   }
@@ -33,21 +35,16 @@ function run(path, localCall) {
 
 // load and run the module
 // must have a manifest.json or this will throw
-module.exports = (pluginPath) => {
-  const manifest = require(path.join(pluginPath, 'manifest.json'))
+module.exports = (pluginPath, localCall) => {
   const { proc, sream } = run(
     path.join(pluginPath, 'bin'),
-    // in practice, the localCall method is created
-    // from the local api and manifest
-    function localCall(type, name, args) {
-      console.log('CALLED', type, name, args)
-      var cb = args.pop()
-      cb(null, { okay: true })
-    }
+    localCall
   )
   return {
     proc: proc,
     child: sream,
-    manifest: manifest
+    //needed by test/standalone otherwise remove this
+    manifest: require(path.join(pluginPath, 'manifest.json'))
   }
 }
+


### PR DESCRIPTION
This thing is quite confusing to work with because it's hard to remember if any given code is running inside the child process or the parent, especially since each side has a "localCall" etc. Anyway, I got test/load.js working again.
first I thought it was console.log inside run-standalone.js was breaking it (because the child process communicates with parent via stdout, so logging anything to standard out will break that... but that didn't seem to be it. Then I saw that run.js had a hardcoded localCall (local in this case meaning the parent process) which always replied `{okay: true}`. I fixed that so that it actually called the server (using muxrpc/local-api) (TODO: insert permissions here) then I discovered that secret-stack doesn't actually expose getAddress in the manifest.

I don't quite understand what's happening in run-standalone, but test/load.js and test/standalone.js both pass, but `npm test` doesn't. Would figure that out but gotta go to the airport right now!